### PR TITLE
fix the examples build script

### DIFF
--- a/examples/wscript
+++ b/examples/wscript
@@ -18,5 +18,5 @@
 ###############################################################################
 
 def build(bld):
-    obj = bld.create_ns3_program('rmcat-example', ['rmcat'])
+    obj = bld.create_ns3_program('rmcat-example', ['ns3-rmcat'])
     obj.source = 'rmcat-example.cc',


### PR DESCRIPTION
error "program 'rmcat-example' not found.." when `./waf --run "rmcat-example"`

