### PR TITLE
Added RTP header. Adapted RmcatSender, RmcatReceiver, and congestion control

### DIFF
--- a/model/apps/rmcat-receiver.h
+++ b/model/apps/rmcat-receiver.h
@@ -45,7 +45,7 @@ private:
     virtual void StopApplication ();
 
     void RecvPacket (Ptr<Socket> socket);
-    void SendFeedback (uint32_t sequence,
+    void SendFeedback (uint16_t sequence,
                        uint64_t recvTimestamp);
 
 private:

--- a/model/apps/rmcat-sender.h
+++ b/model/apps/rmcat-sender.h
@@ -63,7 +63,7 @@ private:
 
     void EnqueuePacket ();
     void SendPacket (uint64_t msSlept);
-    void SendOverSleep (uint32_t seq, uint32_t bytesToSend);
+    void SendOverSleep (uint16_t seq, int64_t nowUs, uint32_t bytesToSend);
     void RecvPacket (Ptr<Socket> socket);
     void CalcBufferParams (uint64_t now);
 
@@ -76,8 +76,9 @@ private:
     float m_minBw;
     float m_maxBw;
     bool m_paused;
-    uint32_t m_flowId;
-    uint32_t m_sequence;
+    uint32_t m_srcId;
+    uint16_t m_sequence;
+    uint32_t m_rtpTsOffset;
     Ptr<Socket> m_socket;
     EventId m_enqueueEvent;
     EventId m_sendEvent;

--- a/model/apps/rtp-header.cc
+++ b/model/apps/rtp-header.cc
@@ -1,0 +1,197 @@
+/******************************************************************************
+ * Copyright 2016-2018 Cisco Systems, Inc.                                    *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License");            *
+ * you may not use this file except in compliance with the License.           *
+ *                                                                            *
+ * You may obtain a copy of the License at                                    *
+ *                                                                            *
+ *     http://www.apache.org/licenses/LICENSE-2.0                             *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ ******************************************************************************/
+
+/**
+ * @file
+ * Header implementation of RTP packets (RFC 3550) for ns3-rmcat.
+ *
+ * @version 0.1.1
+ * @author Jiantao Fu
+ * @author Sergio Mena
+ * @author Xiaoqing Zhu
+ */
+
+#include "rtp-header.h"
+
+namespace ns3 {
+
+RtpHeader::RtpHeader ()
+: m_padding{false}
+, m_extension{false}
+, m_marker{false}
+, m_payloadType{0}
+, m_sequence{0}
+, m_timestamp{0}
+, m_ssrc{0}
+, m_csrc{}
+{}
+
+RtpHeader::~RtpHeader () {}
+
+TypeId RtpHeader::GetTypeId ()
+{
+    static TypeId tid = TypeId ("RtpHeader")
+      .SetParent<Header> ()
+      .AddConstructor<RtpHeader> ()
+    ;
+    return tid;
+}
+
+TypeId RtpHeader::GetInstanceTypeId () const
+{
+    return GetTypeId ();
+}
+
+uint32_t RtpHeader::GetSerializedSize () const
+{
+    NS_ASSERT (m_csrc.size () <= 0x0f);
+    return 2 + // First two octets
+           sizeof (m_sequence)  +
+           sizeof (m_timestamp) +
+           sizeof (m_ssrc) +
+           (m_csrc.size () & 0x0f) * sizeof (decltype (m_csrc)::value_type);
+}
+
+void RtpHeader::Serialize (Buffer::Iterator start) const
+{
+    NS_ASSERT (m_csrc.size () <= 0x0f);
+    NS_ASSERT (m_payloadType <= 0x7f);
+
+    const uint8_t csrcCount = (m_csrc.size () & 0x0f);
+    uint8_t octet1 = 0;
+    octet1 |= (RTP_VERSION << 6);
+    SetBit (octet1, 5, m_padding);
+    SetBit (octet1, 4, m_extension);
+    octet1 |= uint8_t (csrcCount);
+    start.WriteU8 (octet1);
+
+    uint8_t octet2 = 0;
+    SetBit (octet2, 7, m_marker);
+    octet2 |= (m_payloadType & 0x7f);
+    start.WriteU8 (octet2);
+
+    start.WriteHtonU16 (m_sequence);
+    start.WriteHtonU32 (m_timestamp);
+    start.WriteHtonU32 (m_ssrc);
+    for (size_t i = 0; i < csrcCount; ++i) {
+        start.WriteHtonU32 (m_csrc[i]);
+    }
+}
+
+uint32_t RtpHeader::Deserialize (Buffer::Iterator start)
+{
+    const auto octet1 = start.ReadU8 ();
+    const uint8_t version = (octet1 >> 6);
+    m_padding = GetBit (octet1, 5);
+    m_extension = GetBit (octet1, 4);
+    const uint8_t csrcCount = (octet1 & 0x0f);
+
+    const auto octet2 = start.ReadU8 ();
+    m_marker = GetBit (octet2, 7);
+    m_payloadType = (octet2 & 0x7f);
+
+    m_sequence = start.ReadNtohU16 ();
+    m_timestamp = start.ReadNtohU32 ();
+    m_ssrc = start.ReadNtohU32 ();
+    m_csrc.clear ();
+    for (size_t i = 0; i < csrcCount; ++i) {
+        m_csrc.push_back (start.ReadNtohU32 ());
+    }
+    NS_ASSERT (version == RTP_VERSION);
+    return GetSerializedSize ();
+}
+
+void RtpHeader::Print (std::ostream &os) const
+{
+    NS_ASSERT (m_csrc.size () <= 0x0f);
+    os << "RtpHeader - version = " << RTP_VERSION
+       << ", padding =" << (m_padding ? "yes" : "no")
+       << ", extension = " << (m_extension ? "yes" : "no")
+       << ", CSRC count = " << m_csrc.size ()
+       << ", marker = " << (m_marker ? "yes" : "no")
+       << ", payload type = " << m_payloadType
+       << ", sequence = " << m_sequence
+       << ", timestamp = " << m_timestamp
+       << ", ssrc = " << m_ssrc;
+    for (size_t i = 0; i < (m_csrc.size () & 0x0f); ++i) {
+        os << ", CSRC#" << i << " = " << m_csrc[i];
+    }
+    os << std::endl;
+}
+
+void RtpHeader::SetBit (uint8_t& val, uint8_t pos, bool bit)
+{
+    if (bit) {
+        val |= (1 << pos);
+    } else {
+        val &= (~(1u << pos));
+    }
+}
+
+bool RtpHeader::GetBit (uint8_t val, uint8_t pos)
+{
+    return bool (val & (1 << pos));
+}
+
+
+
+FeedbackHeader::~FeedbackHeader () {}
+
+TypeId FeedbackHeader::GetTypeId (void)
+{
+    static TypeId tid = TypeId ("FeedbackHeader")
+      .SetParent<Header> ()
+      .AddConstructor<FeedbackHeader> ()
+    ;
+    return tid;
+}
+
+TypeId FeedbackHeader::GetInstanceTypeId (void) const
+{
+    return GetTypeId ();
+}
+
+uint32_t FeedbackHeader::GetSerializedSize (void) const
+{
+    return sizeof (flow_id)      +
+           sizeof (sequence)     +
+           sizeof (receive_tstmp);
+}
+
+void FeedbackHeader::Serialize (Buffer::Iterator start) const
+{
+    start.WriteHtonU32 (flow_id);
+    start.WriteHtonU32 (sequence);
+    start.WriteHtonU64 (receive_tstmp);
+}
+
+uint32_t FeedbackHeader::Deserialize (Buffer::Iterator start)
+{
+    flow_id = start.ReadNtohU32 ();
+    sequence = start.ReadNtohU32 ();
+    receive_tstmp = start.ReadNtohU64 ();
+    return GetSerializedSize ();
+}
+
+void FeedbackHeader::Print (std::ostream &os) const
+{
+    os << "FeedbackHeader - flow_id = " << flow_id
+       << ", sequence = " << sequence
+       << ",receive_tstmp = " << receive_tstmp;
+}
+
+}

--- a/model/apps/rtp-header.h
+++ b/model/apps/rtp-header.h
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright 2016-2017 Cisco Systems, Inc.                                    *
+ * Copyright 2016-2018 Cisco Systems, Inc.                                    *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License");            *
  * you may not use this file except in compliance with the License.           *
@@ -17,7 +17,7 @@
 
 /**
  * @file
- * Common header interface for rmcat ns3 module.
+ * Header interface of RTP packets (RFC 3550) for ns3-rmcat.
  *
  * @version 0.1.1
  * @author Jiantao Fu
@@ -25,33 +25,36 @@
  * @author Xiaoqing Zhu
  */
 
-#ifndef RMCAT_HEADER_H
-#define RMCAT_HEADER_H
+#ifndef RTP_HEADER_H
+#define RTP_HEADER_H
 
 #include "ns3/header.h"
 #include "ns3/type-id.h"
 
 namespace ns3 {
 
-// TODO (deferred) conform to RTP header formatting
-//
-//---------------------- MEDIA HEADER -----------------------------//
+//-------------------- RTP HEADER (RFC 3550) ----------------------//
 //   0                   1                   2                   3
 //   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                           flow_id                             |
+//  |V=2|P|X|  CC   |M|     PT      |       sequence number         |
 //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                          sequence                             |
+//  |                           timestamp                           |
 //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                     send t(ime)st(a)mp  (1)                   |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                     send t(ime)st(a)mp  (2)                   |
-//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-//  |                          packet size                          |
+//  |           synchronization source (SSRC) identifier            |
 //  +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+
-class MediaHeader : public ns3::Header
+//  |            contributing source (CSRC) identifiers             |
+//  |                             ....                              |
+//  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+#define RTP_VERSION    2
+
+class RtpHeader : public ns3::Header
 {
 public:
+    RtpHeader ();
+    virtual ~RtpHeader ();
+
     static ns3::TypeId GetTypeId ();
     virtual ns3::TypeId GetInstanceTypeId () const;
     virtual uint32_t GetSerializedSize () const;
@@ -59,10 +62,19 @@ public:
     virtual uint32_t Deserialize (ns3::Buffer::Iterator start);
     virtual void Print (std::ostream &os) const;
 
-    uint32_t flow_id;
-    uint32_t sequence;
-    uint64_t send_tstmp;
-    uint32_t packet_size;
+    bool m_padding;
+    bool m_extension;
+    bool m_marker;
+    uint8_t m_payloadType;
+    uint16_t m_sequence;
+    uint32_t m_timestamp;
+    uint32_t m_ssrc;
+    std::vector<uint32_t> m_csrc;
+
+protected:
+    static void SetBit (uint8_t& val, uint8_t pos, bool bit);
+    static bool GetBit (uint8_t val, uint8_t pos);
+
 };
 
 
@@ -100,4 +112,4 @@ public:
 
 }
 
-#endif /* RMCAT_HEADER_H */
+#endif /* RTP_HEADER_H */

--- a/model/congestion-control/dummy-controller.cc
+++ b/model/congestion-control/dummy-controller.cc
@@ -58,7 +58,7 @@ void DummyController::reset() {
 }
 
 bool DummyController::processFeedback(uint64_t now,
-                                      uint32_t sequence,
+                                      uint16_t sequence,
                                       uint64_t rxTimestamp,
                                       uint8_t ecn) {
     // First of all, call the superclass

--- a/model/congestion-control/dummy-controller.h
+++ b/model/congestion-control/dummy-controller.h
@@ -63,7 +63,7 @@ public:
      * prints calculated metrics at regular intervals
      */
     virtual bool processFeedback(uint64_t now,
-                                 uint32_t sequence,
+                                 uint16_t sequence,
                                  uint64_t rxTimestamp,
                                  uint8_t ecn=0);
     /**

--- a/model/congestion-control/nada-controller.cc
+++ b/model/congestion-control/nada-controller.cc
@@ -146,7 +146,7 @@ void NadaController::reset() {
  * TODO: (deferred) Add support for ECN marking
  */
 bool NadaController::processFeedback(uint64_t now,
-                                     uint32_t sequence,
+                                     uint16_t sequence,
                                      uint64_t rxTimestamp,
                                      uint8_t ecn) {
     /* First of all, call the superclass */
@@ -243,7 +243,7 @@ void NadaController::updateMetrics(uint64_t now) {
     }
 
     float avgInt;
-    uint32_t currentInt;
+    uint16_t currentInt;
     bool avgIntOK = getLossIntervalInfo(avgInt, currentInt);
     m_lossesSeen = avgIntOK;
     if (avgIntOK) {

--- a/model/congestion-control/nada-controller.h
+++ b/model/congestion-control/nada-controller.h
@@ -66,7 +66,7 @@ public:
 
     /** NADA's implementation of the #processFeedback API */
     virtual bool processFeedback(uint64_t now,
-                                 uint32_t sequence,
+                                 uint16_t sequence,
                                  uint64_t rxTimestamp,
                                  uint8_t ecn=0);
 
@@ -182,7 +182,7 @@ private:
     float m_Xprev;  /**< previous value of the aggregated congestion signal (x_prev in rmcat-nada), in ms */
     float m_RecvR;  /**< updated receiving rate in bps */
     float m_avgInt; /**< Average inter-loss interval in packets, according to RFC 5348 */
-    uint32_t m_currInt; /**< Most recent (currently growing) inter-loss interval in packets; called I_0 in RFC 5348 */
+    uint16_t m_currInt; /**< Most recent (currently growing) inter-loss interval in packets; called I_0 in RFC 5348 */
     bool m_lossesSeen; /**< Whether packet losses/reorderings have been detected so far */
 };
 

--- a/model/congestion-control/sender-based-controller.cc
+++ b/model/congestion-control/sender-based-controller.cc
@@ -136,7 +136,7 @@ void SenderBasedController::updateInterLossData(const PacketRecord& packet) {
 }
 
 bool SenderBasedController::processSendPacket(uint64_t txTimestamp,
-                                              uint32_t sequence,
+                                              uint16_t sequence,
                                               uint32_t size) {
     if (m_firstSend) {
         m_lastSequence = sequence - 1;
@@ -173,7 +173,7 @@ bool SenderBasedController::processSendPacket(uint64_t txTimestamp,
 }
 
 bool SenderBasedController::processFeedback(uint64_t now,
-                                            uint32_t sequence,
+                                            uint16_t sequence,
                                             uint64_t rxTimestamp,
                                             uint8_t ecn) {
     if (lessThan(m_lastSequence, sequence)) {
@@ -347,7 +347,7 @@ bool SenderBasedController::getPktLossInfo(uint32_t& nLoss, float& plr) const {
     }
 
     // This will wrap properly
-    const uint32_t seqSpan = 1u + m_packetHistory.back().sequence
+    const uint16_t seqSpan = 1u + m_packetHistory.back().sequence
                              - m_packetHistory.front().sequence;
     assert(seqSpan >= m_packetHistory.size());
     nLoss = seqSpan - m_packetHistory.size();
@@ -386,7 +386,7 @@ bool SenderBasedController::getCurrentRecvRate(float& rrateBps) const {
 }
 
 
-bool SenderBasedController::getLossIntervalInfo(float& avgInterval, uint32_t& currentInterval) const {
+bool SenderBasedController::getLossIntervalInfo(float& avgInterval, uint16_t& currentInterval) const {
     if (!m_ilState.initialized) {
         return false; // No losses yet --> no intervals
     }

--- a/model/congestion-control/sender-based-controller.h
+++ b/model/congestion-control/sender-based-controller.h
@@ -46,8 +46,8 @@ const uint32_t RMCAT_LOG_PRINT_PRECISION = 2;  /* default precision for logs */
 class InterLossState {
 public:
     InterLossState();
-    std::deque<uint32_t> intervals;
-    uint32_t expectedSeq;
+    std::deque<uint16_t> intervals;
+    uint16_t expectedSeq;
     bool initialized; // did the first loss happen?
 };
 
@@ -92,14 +92,14 @@ public:
 
     /** To avoid future complexity and defects, we make the following
      *  assumptions regarding wrapping of unsigned integers:
-     *    - sequences, uint32_t, can wrap (just like TCP)
+     *    - sequences, uint16_t, can wrap (just like TCP)
      *    - timestamps, uint64_t, can wrap (despite being 64 bits long)
      *    - delays, uint64_t, can wrap (easily), as they are obtained from
      *      subtraction of timestamps obtained at different endpoints,
      *      which may have non-synchronized clocks.
      */
     struct PacketRecord {
-        uint32_t sequence;
+        uint16_t sequence;
         uint64_t txTimestamp;
         uint32_t size;
         uint64_t owd;
@@ -193,7 +193,7 @@ public:
      *                               function's logic
      */
     virtual bool processSendPacket(uint64_t txTimestamp,
-                                   uint32_t sequence,
+                                   uint16_t sequence,
                                    uint32_t size); // in Bytes
 
     /**
@@ -222,7 +222,7 @@ public:
      *                               function's logic
      */
     virtual bool processFeedback(uint64_t now,
-                                 uint32_t sequence,
+                                 uint16_t sequence,
                                  uint64_t rxTimestamp,
                                  uint8_t ecn=0);
 
@@ -333,10 +333,10 @@ protected:
      *         inter-loss intervals to return; in this case, the output parameters are not
      *         valid). True otherwise
      */
-    bool getLossIntervalInfo(float& avgInterval, uint32_t& currentInterval) const;
+    bool getLossIntervalInfo(float& avgInterval, uint16_t& currentInterval) const;
 
     bool m_firstSend; /**< true if at least one packet has been sent */
-    uint32_t m_lastSequence; /**< sequence of the last packet sent */
+    uint16_t m_lastSequence; /**< sequence of the last packet sent */
     /**
      * Estimation of the network propagation delay, plus clock difference
      * between sender and receiver endpoints

--- a/wscript
+++ b/wscript
@@ -22,7 +22,7 @@ def build(bld):
     module.source = [
         'model/apps/rmcat-sender.cc',
         'model/apps/rmcat-receiver.cc',
-        'model/apps/rmcat-header.cc',
+        'model/apps/rtp-header.cc',
         'model/syncodecs/syncodecs.cc',
         'model/syncodecs/traces-reader.cc',
         'model/congestion-control/sender-based-controller.cc',
@@ -53,7 +53,7 @@ def build(bld):
         'model/apps/rmcat-constants.h',
         'model/apps/rmcat-sender.h',
         'model/apps/rmcat-receiver.h',
-        'model/apps/rmcat-header.h',
+        'model/apps/rtp-header.h',
         'model/syncodecs/syncodecs.h',
         'model/syncodecs/traces-reader.h',
         'model/congestion-control/sender-based-controller.h',


### PR DESCRIPTION
This the first part as discussed during our meeting.
* Media packets use now RTP headers
* Feedback packets are still on the old ad-hoc header (working on a further patch with this direction)